### PR TITLE
Watch should log to std.err

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -722,7 +722,7 @@ function watch(file, rootFile) {
   // watch the file itself
   watchers[file] = {};
   watchers[file][rootFile] = true;
-  console.log('  \033[90mwatching\033[0m %s', file);
+  console.error('  \033[90mwatching\033[0m %s', file);
   // if is windows use fs.watch api instead
   // TODO: remove watchFile when fs.watch() works on osx etc
   if (isWindows) {


### PR DESCRIPTION
Currently when using ```-w``` or ```---watch``` the logging is done with console.log not console.error.  Due to this you end up getting unwanted character in the output from ```-p```