### PR TITLE
Exit process if print and watch both used

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -722,7 +722,11 @@ function watch(file, rootFile) {
   // watch the file itself
   watchers[file] = {};
   watchers[file][rootFile] = true;
-  if (!print) console.log('  \033[90mwatching\033[0m %s', file);
+  if (print) {
+    console.error('Stylus CLI Error: Watch and print cannot be used together');
+    process.exit(1);
+  }
+  console.log('  \033[90mwatching\033[0m %s', file);
   // if is windows use fs.watch api instead
   // TODO: remove watchFile when fs.watch() works on osx etc
   if (isWindows) {


### PR DESCRIPTION
With the current implementation there is effectively no way that watch and print can be used together.  As such the application should exit with a clear message if this edge case is reached.