### PR TITLE
Fix incorrect filenames included in source maps

### DIFF
--- a/lib/visitor/sourcemapper.js
+++ b/lib/visitor/sourcemapper.js
@@ -38,8 +38,16 @@ var SourceMapper = module.exports = function SourceMapper(root, options){
   this.basePath = sourcemap.basePath || '.';
   this.inline = sourcemap.inline;
   this.comment = sourcemap.comment;
+  var filename;
+  if (extname(this.dest) === '.css') {
+    filename = basename(this.dest);
+  }
+  else {
+    filename = basename(this.filename, extname(this.filename)) + '.css';
+  }
+  
   this.map = new SourceMapGenerator({
-    file: basename(this.filename, extname(this.filename)) + '.css',
+    file: filename,
     sourceRoot: sourcemap.sourceRoot || null
   });
   Compiler.call(this, root, options);


### PR DESCRIPTION
This was an edge case introduced when compiling single files with specific output.  The current logic was building the filename in the source maps base on input name.