### PR TITLE
Fix build error for multiple files

### DIFF
--- a/bin/stylus
+++ b/bin/stylus
@@ -395,6 +395,10 @@ function help(name) {
 
 // Compilation options
 
+if (files.length > 1 && extname(dest) !== '') {
+  dest = dirname(dest);
+}
+
 var options = {
     filename: 'stdin'
   , compress: compress


### PR DESCRIPTION
If multiple files are being built, but a dest of a single file is provided things were exploding.  This patch cleans things up so that the files are written to the provided path with expected file name.

It may be preferable to alternatively throw here and force the user to correct their command.  This change would be fairly trivial