### PR TITLE
Install dependencies during make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: deps build
+
 build:
 	./node_modules/stylus/bin/stylus s/style.styl && \
 	./node_modules/stylus/bin/stylus s/style.ie.styl
@@ -8,4 +10,9 @@ try:
 serve:
 	jekyll serve --watch --config _config.yml,_config-dev.yml
 
-.PHONY: build try serve
+deps:
+	which bundle || gem install bundler
+	bundle check || bundle install
+	npm install
+
+.PHONY: all build try serve deps


### PR DESCRIPTION
This allows someone with Node and Ruby installed to simply type `make` to install all dependencies and build the site.