### PR TITLE
Nicer syntax in examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ $ npm install stylus -g
 
 ### Example
 
-```
+```sass
 border-radius()
   -webkit-border-radius: arguments
   -moz-border-radius: arguments
@@ -46,7 +46,7 @@ form input {
 
 the following is equivalent to the indented version of Stylus source, using the CSS syntax instead:
 
-```
+```sass
 border-radius() {
   -webkit-border-radius: arguments
   -moz-border-radius: arguments


### PR DESCRIPTION
Nicer syntax in examples using SASS that have a close syntax instead of nothing.