### PR TITLE
remove hex color 6 digit to 3 digit compress

### DIFF
--- a/lib/nodes/rgba.js
+++ b/lib/nodes/rgba.js
@@ -269,7 +269,7 @@ RGBA.prototype.operate = function(op, right){
 };
 
 /**
- * Return #nnnnnn, #nnn, or rgba(n,n,n,n) string representation of the color.
+ * Return #nnnnnn or rgba(n,n,n,n) string representation of the color.
  *
  * @return {String}
  * @api public
@@ -286,13 +286,8 @@ RGBA.prototype.toString = function(){
     var r = pad(this.r)
       , g = pad(this.g)
       , b = pad(this.b);
-
-    // Compress
-    if (r[0] == r[1] && g[0] == g[1] && b[0] == b[1]) {
-      return '#' + r[0] + g[0] + b[0];
-    } else {
-      return '#' + r + g + b;
-    }
+      
+    return '#' + r + g + b;
   } else {
     return 'rgba('
       + this.r + ','


### PR DESCRIPTION
... for this exceeds the actual job stylus is there to be doing. The more concrete damage: compression breaks certain filter properties in IE9, e.g. in "filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr='#ffe680', endColorstr='#fc0')".